### PR TITLE
Use CFBundleVersion instead of CFBundleShortVersionString

### DIFF
--- a/Opera/Opera.munki.recipe
+++ b/Opera/Opera.munki.recipe
@@ -52,6 +52,29 @@
         <dict>
             <key>Arguments</key>
             <dict>
+                <key>input_plist_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Opera.app/Contents/Info.plist</string>
+                <key>plist_version_key</key>
+                <string>CFBundleVersion</string>
+            </dict>
+            <key>Processor</key>
+            <string>Versioner</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>version</key>
+                    <string>%version%</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
                 <key>additional_makepkginfo_options</key>
                 <array>
                     <string>--destinationpath</string>


### PR DESCRIPTION
Not sure how you feel about this change... Opera has seen a lot of small build number changes lately and this PR changes the version handling for Munki: `27.0.1689.69` instead of `27.0`.