### PR TITLE
Change inline comment to separate key/value pair

### DIFF
--- a/Opera/Opera.download.recipe
+++ b/Opera/Opera.download.recipe
@@ -57,8 +57,8 @@
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Opera.app</string>
                 <key>requirement</key>
                 <string>identifier "com.operasoftware.Opera" and certificate leaf = H"261cd515406974afa19778f62e5d916ec977ebf4"</string>
-				<key>requirement-comment</key>
-				<string>The requirement string can be found with codesign: `codesign --display -v -r- /Volumes/Opera/Opera.app`</string>
+                <key>requirement-comment</key>
+                <string>The requirement string can be found with codesign: `codesign --display -v -r- /Volumes/Opera/Opera.app`</string>
             </dict>
         </dict>
     </array>

--- a/Opera/Opera.download.recipe
+++ b/Opera/Opera.download.recipe
@@ -55,12 +55,10 @@
             <dict>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Opera.app</string>
-                <!--
-                The requirement string can be found with codesign:
-                codesign --display -v -r- /Volumes/Opera/Opera.app
-                -->
                 <key>requirement</key>
                 <string>identifier "com.operasoftware.Opera" and certificate leaf = H"261cd515406974afa19778f62e5d916ec977ebf4"</string>
+				<key>requirement-comment</key>
+				<string>The requirement string can be found with codesign: `codesign --display -v -r- /Volumes/Opera/Opera.app`</string>
             </dict>
         </dict>
     </array>


### PR DESCRIPTION
The double dash in front of `--display` was hindering automatic parsing of the Opera download recipe using Python's plistlib.