### PR TITLE
CodeSignatureVerifier requirement string changed

### DIFF
--- a/Opera/Opera.download.recipe
+++ b/Opera/Opera.download.recipe
@@ -56,7 +56,7 @@
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Opera.app</string>
                 <key>requirement</key>
-                <string>identifier "com.operasoftware.Opera" and certificate leaf = H"261cd515406974afa19778f62e5d916ec977ebf4"</string>
+                <string>identifier "com.operasoftware.Opera" and certificate leaf = H"cdf1c39967986616b6cd64c6bd04833a9cb7450d"</string>
                 <key>requirement-comment</key>
                 <string>The requirement string can be found with codesign: `codesign --display -v -r- /Volumes/Opera/Opera.app`</string>
             </dict>


### PR DESCRIPTION
CodeSignatureVerifier requirement string changed to identifier "com.operasoftware.Opera" and certificate leaf = H"cdf1c39967986616b6cd64c6bd04833a9cb7450d"