### PR TITLE
JASP: set munki minimum os to 10.12

### DIFF
--- a/JASP/JASP.munki.recipe
+++ b/JASP/JASP.munki.recipe
@@ -30,6 +30,8 @@
 			<string>JASP</string>
 			<key>name</key>
 			<string>%NAME%</string>
+			<key>minimum_os_version</key>
+			<string>10.12.0</string>
 			<key>unattended_install</key>
 			<true/>
 		</dict>


### PR DESCRIPTION
It appears that JASP 0.9+ has been built for 10.12+. There is a special build for older versions available, but I guess the new default will require 10.12.