### PR TITLE
Update DisplayLink.download.recipe

### DIFF
--- a/DisplayLink/DisplayLink.download.recipe
+++ b/DisplayLink/DisplayLink.download.recipe
@@ -11,9 +11,9 @@
 		<key>NAME</key>
 		<string>DisplayLink</string>
 		<key>DOWNLOAD_URL</key>
-		<string>http://www.displaylink.com/downloads/macos</string>
+		<string>https://www.displaylink.com/downloads/macos</string>
 		<key>CURL</key>
-		<string>curl -v -F 'fileId=1033' -F 'accept_submit=Accept' http://www.displaylink.com/downloads/file?id=1033</string>
+		<string>curl -v -F 'fileId=1033' -F 'accept_submit=Accept' https://www.displaylink.com/downloads/file?id=1033</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
@@ -44,7 +44,7 @@
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
 				<key>url</key>
-				<string>http://www.displaylink.com/downloads/file?id=%match%</string>
+				<string>https://www.displaylink.com/downloads/file?id=%match%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
Update URLs from `http` to `https` fixes CodeSignatureVerifier error:

```
CodeSignatureVerifier: hdiutil imageinfo error hdiutil: imageinfo failed - image not recognized
 with image /Users/ladmin/Library/AutoPkg/Cache/local.munki.autopkg_DisplayLink/downloads/DisplayLink.dmg.
/Users/ladmin/Library/AutoPkg/Cache/local.munki.autopkg_DisplayLink/downloads/DisplayLink.dmg is not mounted
Failed.
```
After update:
```
CodeSignatureVerifier: Mounted disk image /Users/ladmin/Library/AutoPkg/Cache/local.munki.autopkg_DisplayLink/downloads/DisplayLink.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "DisplayLink Software Installer.pkg":
```