### PR TITLE
Remove Opera postinstall script

### DIFF
--- a/Opera/Opera.munki.recipe
+++ b/Opera/Opera.munki.recipe
@@ -28,12 +28,6 @@
             <string>Opera</string>
             <key>name</key>
             <string>%NAME%</string>
-            <key>postinstall_script</key>
-            <string>#!/bin/bash
-                # Add directory traversal for the entire application and ensure
-                # all executables are executable by group and other
-                /bin/chmod -R go+rX /Applications/Opera.app
-            </string>
             <key>unattended_install</key>
             <true/>
         </dict>


### PR DESCRIPTION
Reverts change 48ea8f0ba17eb5e17d0662e244a332cbc01f1339 made to fix https://github.com/autopkg/bochoven-recipes/issues/11, because the bundle permissions have been fixed by the Opera developers.

```
ls -la /Volumes/Opera/Opera.app/Contents/Versions/63.0.3368.53/Opera\ Framework.framework/
total 24
drwxr-xr-x  6 dfnq  185223974   204B Aug 26 13:03 ./
drwxr-xr-x  8 dfnq  185223974   272B Aug 26 22:32 ../
lrwxr-xr-x  1 dfnq  185223974    24B Aug 28 22:21 Helpers@ -> Versions/Current/Helpers
lrwxr-xr-x  1 dfnq  185223974    32B Aug 28 22:21 Opera Framework@ -> Versions/Current/Opera Framework
lrwxr-xr-x  1 dfnq  185223974    26B Aug 28 22:21 Resources@ -> Versions/Current/Resources
drwxr-xr-x  4 dfnq  185223974   136B Aug 26 13:03 Versions/
```