### PR TITLE
Update variable for pkg_path in NoMADLogin-AD recipe

### DIFF
--- a/Orchard & Grove/NoMADLogin-AD.munki.recipe
+++ b/Orchard & Grove/NoMADLogin-AD.munki.recipe
@@ -50,7 +50,7 @@
                 <key>Arguments</key>
                 <dict>
                     <key>pkg_path</key>
-                    <string>%found_filename%</string>
+                    <string>%pathname%</string>
                     <key>repo_subdirectory</key>
                     <string>%MUNKI_REPO_SUBDIR%</string>
                 </dict>


### PR DESCRIPTION
I updated my autopkg to 1.4.1 today and updated this recipe as well and got the following error:

Error: Error in local.munki.NoMADLogin-AD: Processor: MunkiImporter: Error: creating pkginfo for %found_filename% failed: Traceback (most recent call last):
File "/usr/local/munki/makepkginfo", line 142, in <module>
main()
File "/usr/local/munki/makepkginfo", line 123, in main
item = pkginfo['name']
KeyError: 'name'

I found that the %found_filename% was probably a leftover from the old ZIP retrieval method that was retired, and was not allowing the recipe to proceed as the value would be blank. Since the change was to a direct .pkg download, we can just use %pathname%. Tested on AutoPkg 1.4.1 - no issues found. Did not test on the 2.0RC.