### PR TITLE
Updated JASP regex for the new JASP dmg name

### DIFF
--- a/JASP/JASP.download.recipe
+++ b/JASP/JASP.download.recipe
@@ -23,7 +23,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>://static.jasp-stats.org/(JASP-[\d\.]+).dmg</string>
+				<string>://static.jasp-stats.org/(JASP-[\d\.]+(-Catalina)?).dmg</string>
 				<key>url</key>
 				<string>%DOWNLOAD_URL%</string>
 			</dict>


### PR DESCRIPTION
Added an optional "-Catalina" subgroup to the JASP regex to account for the filename change in more recent JASP downloads. Should retain backwards compatibility with the old style too.

Fixes: `Error in local.munki.JASP: Processor: URLTextSearcher: Error: No match found on URL: https://jasp-stats.org/thank-you-2/`