### PR TITLE
Update JASP.download.recipe

### DIFF
--- a/JASP/JASP.download.recipe
+++ b/JASP/JASP.download.recipe
@@ -23,7 +23,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>://static.jasp-stats.org/(JASP-[\d\.]+).dmg</string>
+				<string>://static.jasp-stats.org/(JASP-[\d\.]+-?\w*).dmg</string>
 				<key>url</key>
 				<string>%DOWNLOAD_URL%</string>
 			</dict>


### PR DESCRIPTION
New version of JASP has appeared - "http://static.jasp-stats.org/JASP-0.13.0.0-Catalina.dmg"

Updated regex search string to catch the new "-Catalina" part. Should also work if they decide to remove it and go back to the previous convention.