### PR TITLE
Updated JASP download URL

### DIFF
--- a/JASP/JASP.download.recipe
+++ b/JASP/JASP.download.recipe
@@ -11,7 +11,7 @@
 	<key>Input</key>
 	<dict>
 		<key>DOWNLOAD_URL</key>
-		<string>https://jasp-stats.org/thank-you-2/</string>
+		<string>https://jasp-stats.org/thank-you-for-downloading-jasp-macos/</string>
 		<key>NAME</key>
 		<string>JASP</string>
 	</dict>


### PR DESCRIPTION
JASP has deprecated the old thank you page, replacing it with new ones that are OS-specific.

Please note that currently, on the new page, the download link links to the Windows installer. I have already emailed JASP asking them to fix this issue.