### PR TITLE
Adjust name of CodeSignatureVerifier argument

### DIFF
--- a/JASP/JASP.download.recipe
+++ b/JASP/JASP.download.recipe
@@ -52,7 +52,7 @@
 			<dict>
 				<key>input_path</key>
 				<string>%pathname%/JASP.app</string>
-				<key>requirements</key>
+				<key>requirement</key>
 				<string>identifier "org.jasp-stats.jasp" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "3T8839ZA6M"</string>
 			</dict>
 		</dict>


### PR DESCRIPTION
The correct argument name for [CodeSignatureVerifier](https://github.com/autopkg/autopkg/wiki/Processor-CodeSignatureVerifier) is `requirement`.