### PR TITLE
Adjust MunkiPkginfoMerger arguments

### DIFF
--- a/ADF/ADF.munki.recipe
+++ b/ADF/ADF.munki.recipe
@@ -54,8 +54,6 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-					<key>pkg_path</key>
-					<string>%dmg_path%</string>
 					<key>additional_pkginfo</key>
 					<dict>
 						<key>items_to_copy</key>

--- a/VU-DAMS/VU_DAMS.munki.recipe
+++ b/VU-DAMS/VU_DAMS.munki.recipe
@@ -48,8 +48,6 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-					<key>pkg_path</key>
-					<string>%dmg_path%</string>
 					<key>additional_pkginfo</key>
 					<dict>
 						<key>items_to_copy</key>


### PR DESCRIPTION
`pkg_path` is not a valid argument for [MunkiPkginfoMerger](https://github.com/autopkg/autopkg/wiki/Processor-MunkiPkginfoMerger).