### PR TITLE
Fix URLs, regex, description & author for G*Power

### DIFF
--- a/Albert-Georg Lang/G*Power.download.recipe
+++ b/Albert-Georg Lang/G*Power.download.recipe
@@ -12,6 +12,8 @@
 	<dict>
 		<key>DOWNLOAD_URL</key>
 		<string>https://www.gpower.hhu.de</string>
+		<key>DOWNLOAD_HOST</key>
+		<string>https://www.psychologie.hhu.de</string>
 		<key>NAME</key>
 		<string>G*Power</string>
 	</dict>
@@ -23,7 +25,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>/fileadmin\/.*/GPowerMac_[\d\.]+.zip</string>
+				<string>/fileadmin/\S+/GPowerMac_[\d\.]+.zip</string>
 				<key>url</key>
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
@@ -36,7 +38,7 @@
 				<key>filename</key>
 				<string>%NAME%.zip</string>
 				<key>url</key>
-				<string>%DOWNLOAD_URL%%match%</string>
+				<string>%DOWNLOAD_HOST%%match%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/Albert-Georg Lang/G*Power.munki.recipe
+++ b/Albert-Georg Lang/G*Power.munki.recipe
@@ -21,9 +21,9 @@
 				<string>testing</string>
 			</array>
 			<key>description</key>
-			<string> </string>
+			<string>G*Power is a tool to compute statistical power analyses for many different t tests, F tests, χ² tests, z tests and some exact tests. G*Power can also be used to compute effect sizes and to display graphically the results of power analyses.</string>
 			<key>developer</key>
-			<string>Albert-Georg Lang</string>
+			<string>The G*Power Team</string>
 			<key>display_name</key>
 			<string>G*Power</string>
 			<key>name</key>


### PR DESCRIPTION
1. The redirect from https://www.gpower.hhu.de to https://www.psychologie.hhu.de breaks the `%DOWNLOAD_URL%%match%` pattern.

2. The HTML is now a single line and the re_pattern was too greedy, limited `\S+`

3. While I was at it, I also integrated the short description and the team name taken from https://www.psychologie.hhu.de/arbeitsgruppen/allgemeine-psychologie-und-arbeitspsychologie/gpower