### PR TITLE
PsychoPy3: Fix github release regex

### DIFF
--- a/PsychoPy/PsychoPy3.download.recipe
+++ b/PsychoPy/PsychoPy3.download.recipe
@@ -25,7 +25,7 @@
 				<key>github_repo</key>
 				<string>%GITHUB_REPO%</string>
 				<key>asset_regex</key>
-				<string>^StandalonePsychoPy3-.*-MacOS.dmg$</string>
+				<string>^StandalonePsychoPy-.*-macOS.dmg$</string>
 			</dict>
 			<key>Processor</key>
 			<string>GitHubReleasesInfoProvider</string>


### PR DESCRIPTION
The last release referencing PsychoPy3 was Release 2020.2.3. They ditched the "3" and also lowercased "macOS" now.