### PR TITLE
PsychoPy3: Increase curl timeout

### DIFF
--- a/PsychoPy/PsychoPy3.download.recipe
+++ b/PsychoPy/PsychoPy3.download.recipe
@@ -14,6 +14,11 @@
 		<string>psychopy/psychopy</string>
 		<key>NAME</key>
 		<string>PsychoPy3</string>
+		<key>curl_opts</key>
+		<array>
+			<string>--speed-time</string>
+			<string>120</string>
+		</array>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>


### PR DESCRIPTION
The dmg takes very long to actually start downloading from github. Maybe they are checking the dmg first, I don't know. They default `--speed-time 30` is not sufficient for this package and the download always fails with curl error 28. Override the speed-time parameter by appending does fix this problem.