### PR TITLE
Updated regex for ADF renaming to AMS

### DIFF
--- a/ADF/ADF.download.recipe
+++ b/ADF/ADF.download.recipe
@@ -21,7 +21,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>https:\/\/downloads.scm.com/Downloads/download%BASEVERSION%/bin/(adf%BASEVERSION%.[\d]+.macintel64.openmpi).dmg</string>
+				<string>https:\/\/downloads.scm.com/Downloads/download%BASEVERSION%/bin/((adf|ams)%BASEVERSION%.[\d]+.macintel64.openmpi).dmg</string>
 				<key>request_headers</key>
 				<dict>
 					<key>Authorization</key>


### PR DESCRIPTION
ADF is now part of the AMS package, instead of ADF being its own product. This means that SCM has updated the download URLs for 2020 and newer. I've added to the regex so you can still match both.

```
autopkg run -v ADF.download.recipe -k BASEVERSION=2021 -k AUTH_HASH="S0m3H4sH"
Processing ADF.download.recipe...
WARNING: ADF.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (match): ams2021.104.macintel64.openmpi
URLDownloader
URLDownloader: Storing new Last-Modified header: Tue, 14 Sep 2021 09:35:15 GMT
URLDownloader: Storing new ETag header: "a19924cf-5cbf14c92985c"
URLDownloader: Downloaded /Users/jc0b/Library/AutoPkg/Cache/com.github.bochoven.recipes.download.ADF/downloads/ams2021.104.macintel64.openmpi.dmg
EndOfCheckPhase
Receipt written to /Users/jc0b/Library/AutoPkg/Cache/com.github.bochoven.recipes.download.ADF/receipts/ADF.download-receipt-20211124-103421.plist

The following new items were downloaded:
    Download Path
    -------------
    /Users/jc0b/Library/AutoPkg/Cache/com.github.bochoven.recipes.download.ADF/downloads/ams2021.104.macintel64.openmpi.dmg
```