### PR TITLE
Update Opera.download.recipe

### DIFF
--- a/Opera/Opera.download.recipe
+++ b/Opera/Opera.download.recipe
@@ -56,7 +56,7 @@
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Opera.app</string>
                 <key>requirement</key>
-                <string>identifier "com.operasoftware.Opera" and certificate leaf = H"cdf1c39967986616b6cd64c6bd04833a9cb7450d"</string>
+                <string>identifier "com.operasoftware.Opera" and certificate leaf = H"89584386993936e6f38e64eed006f705f2570cbf" or certificate leaf = H"cdf1c39967986616b6cd64c6bd04833a9cb7450d"</string>
                 <key>requirement-comment</key>
                 <string>The requirement string can be found with codesign: `codesign --display -v -r- /Volumes/Opera/Opera.app`</string>
             </dict>


### PR DESCRIPTION
Hi, @bochoven 

The Opera download recipe is currently failing with `Processor: CodeSignatureVerifier: Error: Code signature verification failed. Note that all verifications can be disabled by setting the variable DISABLE_CODE_SIGNATURE_VERIFICATION to a non-empty value.`

This PR updates the CodeSignatureVerifier requirement.

Running the recipes does show a warning, but it doesn't seem to make a difference to the run. 

```
/Library/AutoPkg/Python3/Python.framework/Versions/3.10/lib/python3.10/subprocess.py:956: RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode, the default buffer size will be used
  self.stdout = io.open(c2pread, 'rb', bufsize)
/Library/AutoPkg/Python3/Python.framework/Versions/3.10/lib/python3.10/subprocess.py:961: RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode, the default buffer size will be used
  self.stderr = io.open(errread, 'rb', bufsize)
```

Full output from a successful run 

```
autopkg run -vv /Users/paul/Documents/GitHub/AutoPkg\ Repos/bochoven-recipes/Opera/Opera.munki.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/bochoven-recipes/Opera/Opera.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/bochoven-recipes/Opera/Opera.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
OperaUpdateInfoProvider
{'Input': {}}
/Library/AutoPkg/Python3/Python.framework/Versions/3.10/lib/python3.10/subprocess.py:956: RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode, the default buffer size will be used
  self.stdout = io.open(c2pread, 'rb', bufsize)
/Library/AutoPkg/Python3/Python.framework/Versions/3.10/lib/python3.10/subprocess.py:961: RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode, the default buffer size will be used
  self.stderr = io.open(errread, 'rb', bufsize)
OperaUpdateInfoProvider: https://autoupdate.geo.opera.com/netinstaller/Stable/MacOS
OperaUpdateInfoProvider: Version retrieved from opera xml: latest
OperaUpdateInfoProvider: Found URL https://download.opera.com/download/get/?id=60335&autoupdate=1&ni=1&stream=stable
{'Output': {'filename': 'Opera_95.0.4635.37_Autoupdate.tar.xz',
            'url': 'https://download.opera.com/download/get/?id=60335&autoupdate=1&ni=1&stream=stable'}}
URLDownloader
{'Input': {'filename': 'Opera_95.0.4635.37_Autoupdate.tar.xz',
           'request_headers': {'user-agent': 'Opera autoupdate agent/1.0.0'},
           'url': 'https://download.opera.com/download/get/?id=60335&autoupdate=1&ni=1&stream=stable'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/paul/Library/AutoPkg/Cache/com.github.bochoven.recipes.Opera.munki/downloads/Opera_95.0.4635.37_Autoupdate.tar.xz
{'Output': {'pathname': '/Users/paul/Library/AutoPkg/Cache/com.github.bochoven.recipes.Opera.munki/downloads/Opera_95.0.4635.37_Autoupdate.tar.xz'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'purge_destination': True}}
Unarchiver: Guessed archive format 'tar_xz' from filename Opera_95.0.4635.37_Autoupdate.tar.xz
Unarchiver: Unarchived /Users/paul/Library/AutoPkg/Cache/com.github.bochoven.recipes.Opera.munki/downloads/Opera_95.0.4635.37_Autoupdate.tar.xz to /Users/paul/Library/AutoPkg/Cache/com.github.bochoven.recipes.Opera.munki/Opera
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/paul/Library/AutoPkg/Cache/com.github.bochoven.recipes.Opera.munki/Opera/Opera.app',
           'requirement': 'identifier "com.operasoftware.Opera" and '
                          'certificate leaf = '
                          'H"89584386993936e6f38e64eed006f705f2570cbf" or '
                          'certificate leaf = '
                          'H"cdf1c39967986616b6cd64c6bd04833a9cb7450d"'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.bochoven.recipes.Opera.munki/Opera/Opera.app: valid on disk
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.bochoven.recipes.Opera.munki/Opera/Opera.app: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.bochoven.recipes.Opera.munki/Opera/Opera.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
DmgCreator
{'Input': {'dmg_path': '/Users/paul/Library/AutoPkg/Cache/com.github.bochoven.recipes.Opera.munki/Opera.dmg',
           'dmg_root': '/Users/paul/Library/AutoPkg/Cache/com.github.bochoven.recipes.Opera.munki/Opera'}}
DmgCreator: Created dmg from /Users/paul/Library/AutoPkg/Cache/com.github.bochoven.recipes.Opera.munki/Opera at /Users/paul/Library/AutoPkg/Cache/com.github.bochoven.recipes.Opera.munki/Opera.dmg
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '/Users/paul/Library/AutoPkg/Cache/com.github.bochoven.recipes.Opera.munki/Opera/Opera.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleVersion'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Found version 95.0.4635.37 in file /Users/paul/Library/AutoPkg/Cache/com.github.bochoven.recipes.Opera.munki/Opera/Opera.app/Contents/Info.plist
{'Output': {'version': '95.0.4635.37'}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'version': '95.0.4635.37'},
           'pkginfo': {'catalogs': ['testing'],
                       'category': 'Productivity',
                       'description': 'A web browser developed by Opera '
                                      'Software.',
                       'developer': 'Opera',
                       'display_name': 'Opera',
                       'name': 'Opera',
                       'unattended_install': True}}}
MunkiPkginfoMerger: Merged {'version': '95.0.4635.37'} into pkginfo
{'Output': {'pkginfo': {'catalogs': ['testing'],
                        'category': 'Productivity',
                        'description': 'A web browser developed by Opera '
                                       'Software.',
                        'developer': 'Opera',
                        'display_name': 'Opera',
                        'name': 'Opera',
                        'unattended_install': True,
                        'version': '95.0.4635.37'}}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'additional_makepkginfo_options': ['--destinationpath',
                                              '/Applications'],
           'pkg_path': '/Users/paul/Library/AutoPkg/Cache/com.github.bochoven.recipes.Opera.munki/Opera.dmg',
           'pkginfo': {'catalogs': ['testing'],
                       'category': 'Productivity',
                       'description': 'A web browser developed by Opera '
                                      'Software.',
                       'developer': 'Opera',
                       'display_name': 'Opera',
                       'name': 'Opera',
                       'unattended_install': True,
                       'version': '95.0.4635.37'},
           'repo_subdirectory': 'opera/opera',
           'version_comparison_key': 'CFBundleVersion'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/opera/opera/Opera-95.0.4635.37.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/opera/opera/Opera-95.0.4635.37.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'Opera',
                                                       'pkg_repo_path': 'opera/opera/Opera-95.0.4635.37.dmg',
                                                       'pkginfo_path': 'opera/opera/Opera-95.0.4635.37.plist',
                                                       'version': '95.0.4635.37'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'paul',
                                         'creation_date': datetime.datetime(2023, 2, 9, 13, 45, 40),
                                         'munki_version': '5.5.1.4365',
                                         'os_version': '13.2'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'category': 'Productivity',
                           'description': 'A web browser developed by Opera '
                                          'Software.',
                           'developer': 'Opera',
                           'display_name': 'Opera',
                           'installer_item_hash': 'bbf0aa192c92942c423274f403a7bcfcc444c4b0d1ddb65535f59db97306dab6',
                           'installer_item_location': 'opera/opera/Opera-95.0.4635.37.dmg',
                           'installer_item_size': 124534,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'com.operasoftware.Opera',
                                         'CFBundleName': 'Opera',
                                         'CFBundleShortVersionString': '95.0',
                                         'CFBundleVersion': '95.0.4635.37',
                                         'minosversion': '10.11.0',
                                         'path': '/Applications/Opera.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleVersion'}],
                           'items_to_copy': [{'destination_path': '/Applications',
                                              'source_item': 'Opera.app'}],
                           'minimum_os_version': '10.11.0',
                           'name': 'Opera',
                           'unattended_install': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '95.0.4635.37'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/opera/opera/Opera-95.0.4635.37.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/opera/opera/Opera-95.0.4635.37.plist'}}
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.bochoven.recipes.Opera.munki/receipts/Opera.munki-receipt-20230209-134540.plist

The following new items were imported into Munki:
    Name   Version       Catalogs  Pkginfo Path                          Pkg Repo Path                       Icon Repo Path  
    ----   -------       --------  ------------                          -------------                       --------------  
    Opera  95.0.4635.37  testing   opera/opera/Opera-95.0.4635.37.plist  opera/opera/Opera-95.0.4635.37.dmg 
```