### PR TITLE
Get more accurate version information for JASP

### DIFF
--- a/JASP/JASP.download.recipe
+++ b/JASP/JASP.download.recipe
@@ -35,6 +35,19 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>re_pattern</key>
+				<string>://static.jasp-stats.org/JASP-(\d+(\.\d+)+)+-macOS-%ARCHITECTURE%.dmg</string>
+				<key>url</key>
+				<string>%DOWNLOAD_URL%</string>
+				<key>result_output_var_name</key>
+				<string>current_version</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+		</dict>		
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>filename</key>
 				<string>%match%.dmg</string>
 				<key>url</key>

--- a/JASP/JASP.download.recipe
+++ b/JASP/JASP.download.recipe
@@ -25,17 +25,6 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>://static.jasp-stats.org/(JASP-[\d\.]+-macOS-%ARCHITECTURE%).dmg</string>
-				<key>url</key>
-				<string>%DOWNLOAD_URL%</string>
-			</dict>
-			<key>Processor</key>
-			<string>URLTextSearcher</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>re_pattern</key>
 				<string>://static.jasp-stats.org/JASP-(\d+(\.\d+)+)+-macOS-%ARCHITECTURE%.dmg</string>
 				<key>url</key>
 				<string>%DOWNLOAD_URL%</string>
@@ -49,9 +38,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%match%.dmg</string>
+				<string>JASP-%current_version%-macOS-%ARCHITECTURE%.dmg</string>
 				<key>url</key>
-				<string>https://static.jasp-stats.org/%match%.dmg</string>
+				<string>https://static.jasp-stats.org/JASP-%current_version%-macOS-%ARCHITECTURE%.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/JASP/JASP.munki.recipe
+++ b/JASP/JASP.munki.recipe
@@ -31,7 +31,7 @@
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>minimum_os_version</key>
-			<string>10.12.0</string>
+			<string>10.15.0</string>
 			<key>unattended_install</key>
 			<true/>
 		</dict>
@@ -52,12 +52,26 @@
 			<string>AppDmgVersioner</string>
 		</dict>
 		<dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+			<key>Arguments</key>
+			<dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>version</key>
+					<string>%current_version%</string>
+				</dict>
+			</dict>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_path</key>
 				<string>%pathname%</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
+				<key>version_comparison_key</key>
+				<string>CFBundleVersion</string>
 			</dict>
 			<key>Processor</key>
 			<string>MunkiImporter</string>


### PR DESCRIPTION
I noticed that JASP is not updating CFBundleShortVersionString with minor updates.  As a result, the Munki recipe was not importing the new version.  For example, I had a version in my repo with CFBundleShortVersionString = 0.17 and CFBundleVersion = 0.17.1.0   Autopkg then downloaded a version with CFBundleShortVersionString = 0.17 and CFBundleVersion = 0.17.2.0 but did not see it as an update to the version in my Munki repo.

This pull request modifies the download recipe to output the full version number, and modifies the munki recipe to use that version when doing the import.

Question for @bochoven : should I update the pkg recipe as well for consistency?  I don't use the pkg recipe so I left it untouched for now.  I tested to make sure it worked with my download recipe changes, but I see it suffers from the same versioning issue.