### PR TITLE
JASP

### DIFF
--- a/JASP/JASP.download.recipe
+++ b/JASP/JASP.download.recipe
@@ -5,40 +5,38 @@
 	<key>Comment</key>
 	<string>Created with Recipe Robot v1.0.3 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
-	<string>Downloads the latest Intel version of JASP.</string>
+	<string>Downloads the latest Intel version of JASP.
+
+ARCHITECTURE variable use: Intel "x86_64" or Apple Silicon "arm64"</string>
 	<key>Identifier</key>
 	<string>com.github.bochoven.recipes.download.JASP</string>
 	<key>Input</key>
 	<dict>
-		<key>DOWNLOAD_URL</key>
-		<string>https://jasp-stats.org/thank-you-for-downloading-jasp-macos/</string>
 		<key>NAME</key>
 		<string>JASP</string>
 		<key>ARCHITECTURE</key>
-		<string>x86_64</string>
+		<string>arm64</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.1</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>re_pattern</key>
-				<string>://static.jasp-stats.org/(JASP-[\d\.]+-macOS-%ARCHITECTURE%).dmg</string>
-				<key>url</key>
-				<string>%DOWNLOAD_URL%</string>
+				<key>asset_regex</key>
+				<string>JASP-([0-9]+(\.[0-9]+)+)-macOs-%ARCHITECTURE%\.dmg$</string>
+				<key>github_repo</key>
+				<string>jasp-stats/jasp-desktop</string>
 			</dict>
 			<key>Processor</key>
-			<string>URLTextSearcher</string>
+			<string>GitHubReleasesInfoProvider</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%match%.dmg</string>
-				<key>url</key>
-				<string>https://static.jasp-stats.org/%match%.dmg</string>
+				<string>%NAME%-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
@@ -48,8 +46,6 @@
 			<string>EndOfCheckPhase</string>
 		</dict>
 		<dict>
-			<key>Processor</key>
-			<string>CodeSignatureVerifier</string>
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
@@ -57,6 +53,8 @@
 				<key>requirement</key>
 				<string>identifier "org.jasp-stats.jasp" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = AWJJ3YVK9B</string>
 			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
 		</dict>
 	</array>
 </dict>

--- a/JASP/JASP.munki.recipe
+++ b/JASP/JASP.munki.recipe
@@ -30,8 +30,6 @@
 			<string>JASP</string>
 			<key>name</key>
 			<string>%NAME%</string>
-			<key>minimum_os_version</key>
-			<string>10.12.0</string>
 			<key>unattended_install</key>
 			<true/>
 		</dict>


### PR DESCRIPTION
Hi, @bochoven 

The JASP download recipe is currently failing with the following error
```
Processor: URLTextSearcher: Error: No match found on URL: https://jasp-stats.org/thank-you-for-downloading-jasp-macos/
```

This PR 
- Switches download recipe to use `GitHubReleasesInfoProvider`
- Removes munki recipe's hardcoded `minimum_os_version` as this is pulled from the App's info.plist when the installs array is created. 

Output from a successful x86_64 run
```
autopkg run -v /Users/paul.cossey/Documents/GitHub/AutoPkg\ Repos/bochoven-recipes/JASP/JASP.munki.recipe    
Processing /Users/paul.cossey/Documents/GitHub/AutoPkg Repos/bochoven-recipes/JASP/JASP.munki.recipe...
WARNING: /Users/paul.cossey/Documents/GitHub/AutoPkg Repos/bochoven-recipes/JASP/JASP.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
GitHubReleasesInfoProvider: Matched regex 'JASP-([0-9]+(\.[0-9]+)+)-macOs-x86_64\.dmg$' among asset(s): JASP-0.18.0.0-macOs-arm64.dmg, JASP-0.18.0.0-macOs-x86_64.dmg, JASP-0.18.0.0-Windows.msi, JASP-0.18.0.0-Windows.zip
GitHubReleasesInfoProvider: Selected asset 'JASP-0.18.0.0-macOs-x86_64.dmg' from release 'Release 0.18.0'
URLDownloader
URLDownloader: Storing new Last-Modified header: Wed, 06 Sep 2023 09:50:59 GMT
URLDownloader: Storing new ETag header: "0x8DBAEBEC64B86D6"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bochoven.recipes.munki.JASP/downloads/JASP-0.18.0.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bochoven.recipes.munki.JASP/downloads/JASP-0.18.0.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.OzAzXw/JASP.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.OzAzXw/JASP.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.OzAzXw/JASP.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
AppDmgVersioner
AppDmgVersioner: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bochoven.recipes.munki.JASP/downloads/JASP-0.18.0.dmg
AppDmgVersioner: BundleID: org.jasp-stats.jasp
AppDmgVersioner: Version: 0.18
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/JASP/JASP-0.18.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/JASP/JASP-0.18.0-0.18.dmg
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bochoven.recipes.munki.JASP/receipts/JASP.munki-receipt-20230913-151327.plist

The following new items were downloaded:
    Download Path                                                                                              
    -------------                                                                                              
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bochoven.recipes.munki.JASP/downloads/JASP-0.18.0.dmg  

The following new items were imported into Munki:
    Name  Version  Catalogs  Pkginfo Path               Pkg Repo Path                   Icon Repo Path  
    ----  -------  --------  ------------               -------------                   --------------  
    JASP  0.18     testing   apps/JASP/JASP-0.18.plist  apps/JASP/JASP-0.18.0-0.18.dmg 
```

Output from a successful arm64 run
```
autopkg run -v /Users/paul.cossey/Documents/GitHub/AutoPkg\ Repos/bochoven-recipes/JASP/JASP.munki.recipe
Processing /Users/paul.cossey/Documents/GitHub/AutoPkg Repos/bochoven-recipes/JASP/JASP.munki.recipe...
WARNING: /Users/paul.cossey/Documents/GitHub/AutoPkg Repos/bochoven-recipes/JASP/JASP.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
GitHubReleasesInfoProvider: Matched regex 'JASP-([0-9]+(\.[0-9]+)+)-macOs-arm64\.dmg$' among asset(s): JASP-0.18.0.0-macOs-arm64.dmg, JASP-0.18.0.0-macOs-x86_64.dmg, JASP-0.18.0.0-Windows.msi, JASP-0.18.0.0-Windows.zip
GitHubReleasesInfoProvider: Selected asset 'JASP-0.18.0.0-macOs-arm64.dmg' from release 'Release 0.18.0'
URLDownloader
URLDownloader: Storing new Last-Modified header: Wed, 06 Sep 2023 09:28:29 GMT
URLDownloader: Storing new ETag header: "0x8DBAEBBA146DA5F"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bochoven.recipes.munki.JASP/downloads/JASP-0.18.0.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bochoven.recipes.munki.JASP/downloads/JASP-0.18.0.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.R4qjgB/JASP.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.R4qjgB/JASP.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.R4qjgB/JASP.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
AppDmgVersioner
AppDmgVersioner: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bochoven.recipes.munki.JASP/downloads/JASP-0.18.0.dmg
AppDmgVersioner: BundleID: org.jasp-stats.jasp
AppDmgVersioner: Version: 0.18
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/JASP/JASP-0.18__1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/JASP/JASP-0.18.0-0.18__1.dmg
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bochoven.recipes.munki.JASP/receipts/JASP.munki-receipt-20230913-154112.plist

The following new items were downloaded:
    Download Path                                                                                              
    -------------                                                                                              
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bochoven.recipes.munki.JASP/downloads/JASP-0.18.0.dmg  

The following new items were imported into Munki:
    Name  Version  Catalogs  Pkginfo Path                  Pkg Repo Path                      Icon Repo Path  
    ----  -------  --------  ------------                  -------------                      --------------  
    JASP  0.18     testing   apps/JASP/JASP-0.18__1.plist  apps/JASP/JASP-0.18.0-0.18__1.dmg
``` 