### PR TITLE
Add ARCHITECTURE to filename

### DIFF
--- a/JASP/JASP.download.recipe
+++ b/JASP/JASP.download.recipe
@@ -36,7 +36,7 @@ ARCHITECTURE variable use: Intel "x86_64" or Apple Silicon "arm64"</string>
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%-%version%.dmg</string>
+				<string>%NAME%_%ARCHITECTURE%-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
To avoid conflicts when importing both arm and intel.

Before the change, running an arm override of the recipe and then the intel override would result in the downloaded dmgs that were imported into munki being named "JASP-0.18.0-0.18.dmg" and "JASP-0.18.0-0.18__1.dmg" with no indication of which dmg contained which architecture without referencing the munki pkginfo file.

After making this change:
Running the overridden recipe for the arm64 architecture:

autopkg run -v JASP_arm64.munki
Processing JASP_arm64.munki...
GitHubReleasesInfoProvider
GitHubReleasesInfoProvider: Matched regex 'JASP-([0-9]+(\.[0-9]+)+)-macOs-arm64\.dmg$' among asset(s): JASP-0.18.0.0-macOs-arm64.dmg, JASP-0.18.0.0-macOs-x86_64.dmg, JASP-0.18.0.0-Windows.msi, JASP-0.18.0.0-Windows.zip
GitHubReleasesInfoProvider: Selected asset 'JASP-0.18.0.0-macOs-arm64.dmg' from release 'Release 0.18.0'
URLDownloader
URLDownloader: Storing new Last-Modified header: Wed, 06 Sep 2023 09:28:29 GMT
URLDownloader: Storing new ETag header: "0x8DBAEBBA146DA5F"
URLDownloader: Downloaded /Users/Shared/AutoPkg/Cache/local.munki.JASP_arm64/downloads/JASP_arm64-0.18.0.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/Shared/AutoPkg/Cache/local.munki.JASP_arm64/downloads/JASP_arm64-0.18.0.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.NS9ecE/JASP.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.NS9ecE/JASP.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.NS9ecE/JASP.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
AppDmgVersioner
AppDmgVersioner: Mounted disk image /Users/Shared/AutoPkg/Cache/local.munki.JASP_arm64/downloads/JASP_arm64-0.18.0.dmg
AppDmgVersioner: BundleID: org.jasp-stats.jasp
AppDmgVersioner: Version: 0.18
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Volumes/munki1
MunkiImporter: Copied pkginfo to: /Volumes/munki1/pkgsinfo/Apps/JASP/JASP_arm64-0.18.plist
MunkiImporter:            pkg to: /Volumes/munki1/pkgs/Apps/JASP/JASP_arm64-0.18.0-0.18.dmg
Receipt written to /Users/Shared/AutoPkg/Cache/local.munki.JASP_arm64/receipts/JASP_arm64-receipt-20230927-155402.plist

The following new items were downloaded:
    Download Path
    -------------
    /Users/Shared/AutoPkg/Cache/local.munki.JASP_arm64/downloads/JASP_arm64-0.18.0.dmg

The following new items were imported into Munki:
    Name        Version  Catalogs  Pkginfo Path                     Pkg Repo Path                         Icon Repo Path
    ----        -------  --------  ------------                     -------------                         --------------
    JASP_arm64  0.18     autopkg   Apps/JASP/JASP_arm64-0.18.plist  Apps/JASP/JASP_arm64-0.18.0-0.18.dmg

Running the overridden recipe for the intel architecture:

autopkg run -v JASP_arm64.munki
....
The following new items were downloaded:
    Download Path
    -------------
    /Users/Shared/AutoPkg/Cache/local.munki.JASP_x86_64/downloads/JASP_x86_64-0.18.0.dmg

The following new items were imported into Munki:
    Name         Version  Catalogs  Pkginfo Path                      Pkg Repo Path                          Icon Repo Path
    ----         -------  --------  ------------                      -------------                          --------------
    JASP_x86_64  0.18     autopkg   Apps/JASP/JASP_x86_64-0.18.plist  Apps/JASP/JASP_x86_64-0.18.0-0.18.dmg