### PR TITLE
Update CodeSignature for Jasp Download

### DIFF
--- a/JASP/JASP.download.recipe
+++ b/JASP/JASP.download.recipe
@@ -51,7 +51,7 @@ ARCHITECTURE variable use: Intel "x86_64" or Apple Silicon "arm64"</string>
 				<key>input_path</key>
 				<string>%pathname%/JASP.app</string>
 				<key>requirement</key>
-				<string>identifier "org.jasp-stats.jasp" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = AWJJ3YVK9B</string>
+				<string>identifier "org.jaspstats.jasp" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = AWJJ3YVK9B</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>


### PR DESCRIPTION
~ % autopkg run -v jasp.download.recipe
Processing jasp.download.recipe...
GitHubReleasesInfoProvider
GitHubReleasesInfoProvider: Matched regex '(?i)JASP-([0-9]+(\.[0-9]+)+)-macOs-arm64.*\.dmg$' among asset(s): JASP-0.19.0.0-macOS-arm64.dmg, JASP-0.19.0.0-macOS-x86_64.dmg, JASP-0.19.0.0-Windows.msi, JASP-0.19.0.0-Windows.zip
GitHubReleasesInfoProvider: Selected asset 'JASP-0.19.0.0-macOS-arm64.dmg' from release 'Release 0.19.0'
URLDownloader
URLDownloader: Storing new Last-Modified header: Mon, 15 Jul 2024 20:36:11 GMT
URLDownloader: Storing new ETag header: "0x8DCA50DC3DE8B2F"
URLDownloader: Downloaded /Users/Shared/AutoPkg/Cache/local.download.jasp/downloads/JASP_arm64-0.19.0.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/Shared/AutoPkg/Cache/local.download.jasp/downloads/JASP_arm64-0.19.0.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.zwxfIb/JASP.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.zwxfIb/JASP.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.zwxfIb/JASP.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
Receipt written to /Users/Shared/AutoPkg/Cache/local.download.jasp/receipts/jasp.download-receipt-20240718-155942.plist

The following new items were downloaded:
    Download Path                                                                    
    -------------                                                                    
    /Users/Shared/AutoPkg/Cache/local.download.jasp/downloads/JASP_arm64-0.19.0.dmg  