### PR TITLE
Remove App DmgVersioner and set MunkiImporter to use CFBundleVersion

### DIFF
--- a/JASP/JASP.munki.recipe
+++ b/JASP/JASP.munki.recipe
@@ -35,7 +35,7 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.1</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.bochoven.recipes.download.JASP</string>
 	<key>Process</key>
@@ -43,19 +43,12 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>dmg_path</key>
-				<string>%pathname%</string>
-			</dict>
-			<key>Processor</key>
-			<string>AppDmgVersioner</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>pkg_path</key>
 				<string>%pathname%</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
+				<key>version_comparison_key</key>
+				<string>CFBundleVersion</string>
 			</dict>
 			<key>Processor</key>
 			<string>MunkiImporter</string>


### PR DESCRIPTION
For minor updates to JASP, CFBundleVersion will update while CFBundleShortVersionString will not.  This pull request allows minor updates to import correctly into Munki. 