### PR TITLE
pass version to munkiimporter

### DIFF
--- a/JASP/JASP.munki.recipe
+++ b/JASP/JASP.munki.recipe
@@ -49,6 +49,11 @@
 				<string>%MUNKI_REPO_SUBDIR%</string>
 				<key>version_comparison_key</key>
 				<string>CFBundleVersion</string>
+				<key>additional_makepkginfo_options</key>
+				<array>
+					<string>--pkgvers</string>
+					<string>%version%</string>
+				</array>
 			</dict>
 			<key>Processor</key>
 			<string>MunkiImporter</string>


### PR DESCRIPTION
Apologies for the additional pull request.  I should have bought this and included in in the last one.  

This change passes `%version%` from the `GitHubReleasesInfoProvider` step to `MunkiImporter` by way of `additional_makepkginfo_options` 