### PR TITLE
Deprecate NoMAD Login AD recipes

### DIFF
--- a/Orchard & Grove/NoMADLogin-AD.download.recipe
+++ b/Orchard & Grove/NoMADLogin-AD.download.recipe
@@ -14,9 +14,18 @@
             <string>https://files.nomad.menu/NoMAD-Login-AD.pkg</string>
         </dict>
         <key>MinimumVersion</key>
-        <string>0.2.9</string>
+        <string>1.1</string>
         <key>Process</key>
         <array>
+            <dict>
+                <key>Processor</key>
+                <string>DeprecationWarning</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>warning_message</key>
+                    <string>NoMAD Login AD has been archived and will receive no further updates (details: https://www.jamf.com/blog/jamf-to-archive-nomad-open-source-projects/). This recipe is deprecated and will be removed in the future.</string>
+                </dict>
+            </dict>
             <dict>
                 <key>Processor</key>
                 <string>URLDownloader</string>


### PR DESCRIPTION
This PR deprecates the NoMAD Login AD recipes, since the software will be receiving no futher updates ([details](https://www.jamf.com/blog/jamf-to-archive-nomad-open-source-projects/)).
