### PR TITLE
Fix WebDrive recipes and add code signature verification

### DIFF
--- a/WebDrive/WebDrive.download.recipe
+++ b/WebDrive/WebDrive.download.recipe
@@ -30,7 +30,18 @@
 		</dict>
 		<dict>
 			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
+			<string>CodeSignatureVerifier</string>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%</string>
+				<key>expected_authorities</key>
+				<array>
+					<string>Developer ID Installer: South River Technologies (3HVJ8D4999)</string>
+					<string>Developer ID Certification Authority</string>
+					<string>Apple Root CA</string>
+				</array>
+			</dict>
 		</dict>
 	</array>
 </dict>

--- a/WebDrive/WebDrive.download.recipe
+++ b/WebDrive/WebDrive.download.recipe
@@ -10,10 +10,6 @@
 	<dict>
 		<key>NAME</key>
 		<string>webdrive</string>
-		<key>SPARKLE_FEED_URL</key>
-		<string>https://www.southrivertech.com/appcasts/webdrive16.xml</string>
-		<key>USER_AGENT</key>
-		<string>WebDrive for Mac/4.21 Sparkle/313</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.3.1</string>
@@ -21,21 +17,16 @@
 	<array>
 		<dict>
 			<key>Processor</key>
-			<string>SparkleUpdateInfoProvider</string>
+			<string>URLDownloader</string>
 			<key>Arguments</key>
 			<dict>
-				<key>appcast_url</key>
-				<string>%SPARKLE_FEED_URL%</string>
-				<key>appcast_request_headers</key>
-                <dict>
-                        <key>user-agent</key>
-                        <string>%USER_AGENT%</string>
-                </dict>
+				<key>url</key>
+				<string>https://srtcdnstorage.blob.core.windows.net/software/nextgen/webdrive/WebDrive%20Setup.pkg</string>
 			</dict>
 		</dict>
 		<dict>
 			<key>Processor</key>
-			<string>URLDownloader</string>
+			<string>EndOfCheckPhase</string>
 		</dict>
 		<dict>
 			<key>Processor</key>


### PR DESCRIPTION
This PR adjusts the WebDrive download method and adds code signature verification.

```
% autopkg run -vvq 'WebDrive/WebDrive.download.recipe'
Processing WebDrive/WebDrive.download.recipe...
WARNING: WebDrive/WebDrive.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'url': 'https://srtcdnstorage.blob.core.windows.net/software/nextgen/webdrive/WebDrive%20Setup.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 18 Jul 2023 18:26:06 GMT
URLDownloader: Storing new ETag header: 0x8DB87BC73D31452
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.bochoven.recipes.webdrive.download/downloads/WebDrive%20Setup.pkg
{'Output': {'download_changed': True,
            'etag': '0x8DB87BC73D31452',
            'last_modified': 'Tue, 18 Jul 2023 18:26:06 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.bochoven.recipes.webdrive.download/downloads/WebDrive%20Setup.pkg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.bochoven.recipes.webdrive.download/downloads/WebDrive%20Setup.pkg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.bochoven.recipes.webdrive.download/downloads/WebDrive%20Setup.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "WebDrive%20Setup.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2023-02-01 02:37:52 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: South River Technologies (3HVJ8D4999)
CodeSignatureVerifier:        Expires: 2025-02-25 05:17:42 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            ED 0C 38 E4 2A A6 80 70 FF 05 56 A7 C4 4C 90 43 56 0D 97 6D BA E7
CodeSignatureVerifier:            8F F0 77 18 06 D9 30 D0 34 A4
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: WARNING: This recipe is using 'expected_authorities' when it should be using 'expected_authority_names'. This will become an error in future versions of AutoPkg.
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.bochoven.recipes.webdrive.download/receipts/WebDrive.download-receipt-20241225-124216.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.bochoven.recipes.webdrive.download/downloads/WebDrive%20Setup.pkg
```
