### PR TITLE
Fix PsychoPy 3 recipes and add code signature verification, deprecate PsychoPy 2 recipes

### DIFF
--- a/PsychoPy/PsychoPy2.download.recipe
+++ b/PsychoPy/PsychoPy2.download.recipe
@@ -20,6 +20,15 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the PsychoPy3 recipes in this repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>github_repo</key>

--- a/PsychoPy/PsychoPy3.download.recipe
+++ b/PsychoPy/PsychoPy3.download.recipe
@@ -5,20 +5,20 @@
 	<key>Comment</key>
 	<string>Created with Recipe Robot v1.0.3 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
-	<string>Downloads the latest version of PsychoPy3.</string>
+	<string>Downloads the latest version of PsychoPy.
+	
+As of December 2024, valid values for PY_VERS include:
+- 3.8
+- 3.10
+</string>
 	<key>Identifier</key>
 	<string>com.github.bochoven.recipes.download.PsychoPy3</string>
 	<key>Input</key>
 	<dict>
-		<key>GITHUB_REPO</key>
-		<string>psychopy/psychopy</string>
+		<key>PY_VERS</key>
+		<string>3.10</string>
 		<key>NAME</key>
 		<string>PsychoPy3</string>
-		<key>curl_opts</key>
-		<array>
-			<string>--speed-time</string>
-			<string>120</string>
-		</array>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -28,9 +28,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>github_repo</key>
-				<string>%GITHUB_REPO%</string>
+				<string>psychopy/psychopy</string>
 				<key>asset_regex</key>
-				<string>^StandalonePsychoPy-.*-macOS.dmg$</string>
+				<string>^StandalonePsychoPy-[\d\.]+-macOS-%PY_VERS%\.dmg$</string>
 			</dict>
 			<key>Processor</key>
 			<string>GitHubReleasesInfoProvider</string>

--- a/PsychoPy/PsychoPy3.download.recipe
+++ b/PsychoPy/PsychoPy3.download.recipe
@@ -48,6 +48,17 @@ As of December 2024, valid values for PY_VERS include:
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>
 		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%/PsychoPy.app</string>
+				<key>requirement</key>
+				<string>identifier "org.opensciencetools.psychopy" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = NM3SX67P2X</string>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
This PR updates the PsychoPy family of recipes to support the latest release on GitHub, adds code signature verification, and deprecates the non-working PsychoPy2 recipes.

```
% autopkg run -vvq 'PsychoPy/PsychoPy3.download.recipe'
Processing PsychoPy/PsychoPy3.download.recipe...
WARNING: PsychoPy/PsychoPy3.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': '^StandalonePsychoPy-[\\d\\.]+-macOS-3.10\\.dmg$',
           'github_repo': 'psychopy/psychopy'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex '^StandalonePsychoPy-[\d\.]+-macOS-3.10\.dmg$' among asset(s): StandalonePsychoPy-2024.2.4-macOS-3.10.dmg, StandalonePsychoPy-2024.2.4-macOS-3.8.dmg, StandalonePsychoPy-2024.2.4-win64-3.10.exe, StandalonePsychoPy-2024.2.4-win64-3.8.exe
GitHubReleasesInfoProvider: Selected asset 'StandalonePsychoPy-2024.2.4-macOS-3.10.dmg' from release '2024.2.4'
{'Output': {'asset_created_at': '2024-10-25T13:03:14Z',
            'asset_url': 'https://api.github.com/repos/psychopy/psychopy/releases/assets/201702676',
            'release_notes': '# Fixes this release\r\n'
                             '\r\n'
                             '* Recreate .js file on run when piloting in JS '
                             'by @TEParsons in #6920\r\n'
                             '* App failing to start on MacOS if all windows '
                             'closed on last app close by @peircej in #6926\r\n'
                             '* Fix nonslip timing issue in Builder-generated '
                             'PsychoJS code by @TEParsons in #6921\r\n'
                             '\r\n'
                             '**Full Changelog**: '
                             'https://github.com/psychopy/psychopy/compare/2024.2.3...2024.2.4',
            'url': 'https://github.com/psychopy/psychopy/releases/download/2024.2.4/StandalonePsychoPy-2024.2.4-macOS-3.10.dmg',
            'version': '2024.2.4'}}
URLDownloader
{'Input': {'filename': 'PsychoPy3-2024.2.4.dmg',
           'url': 'https://github.com/psychopy/psychopy/releases/download/2024.2.4/StandalonePsychoPy-2024.2.4-macOS-3.10.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 25 Oct 2024 13:06:43 GMT
URLDownloader: Storing new ETag header: "0x8DCF4F5DFB1C28B"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.bochoven.recipes.download.PsychoPy3/downloads/PsychoPy3-2024.2.4.dmg
{'Output': {'download_changed': True,
            'etag': '"0x8DCF4F5DFB1C28B"',
            'last_modified': 'Fri, 25 Oct 2024 13:06:43 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.bochoven.recipes.download.PsychoPy3/downloads/PsychoPy3-2024.2.4.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.bochoven.recipes.download.PsychoPy3/downloads/PsychoPy3-2024.2.4.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.bochoven.recipes.download.PsychoPy3/downloads/PsychoPy3-2024.2.4.dmg/PsychoPy.app',
           'requirement': 'identifier "org.opensciencetools.psychopy" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'NM3SX67P2X'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.bochoven.recipes.download.PsychoPy3/downloads/PsychoPy3-2024.2.4.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.hqbaqe/PsychoPy.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.hqbaqe/PsychoPy.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.hqbaqe/PsychoPy.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.bochoven.recipes.download.PsychoPy3/receipts/PsychoPy3.download-receipt-20241225-121629.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.bochoven.recipes.download.PsychoPy3/downloads/PsychoPy3-2024.2.4.dmg
```
