### PR TITLE
Deprecate GPower recipes

### DIFF
--- a/Albert-Georg Lang/G*Power.download.recipe
+++ b/Albert-Georg Lang/G*Power.download.recipe
@@ -22,6 +22,15 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the G*Power recipes in the dataJar-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>


### PR DESCRIPTION
This PR deprecates the non-functional G*Power recipe family, and points users to the working equivalents in the dataJAR-recipes repo.
