### PR TITLE
Update expected_authorities to expected_authority_names in CodeSignatureVerifier

### DIFF
--- a/WebDrive/WebDrive.download.recipe
+++ b/WebDrive/WebDrive.download.recipe
@@ -35,7 +35,7 @@
 			<dict>
 				<key>input_path</key>
 				<string>%pathname%</string>
-				<key>expected_authorities</key>
+				<key>expected_authority_names</key>
 				<array>
 					<string>Developer ID Installer: South River Technologies (3HVJ8D4999)</string>
 					<string>Developer ID Certification Authority</string>


### PR DESCRIPTION
My previous PR introduced a minor issue: the proper name for this key should be `expected_authority_names`. This PR has the fix.