### PR TITLE
20251122-fix-endofcheckphase

### DIFF
--- a/Orchard & Grove/NoMADLogin-AD.download.recipe
+++ b/Orchard & Grove/NoMADLogin-AD.download.recipe
@@ -37,6 +37,10 @@
             </dict>
             <dict>
                 <key>Processor</key>
+                <string>EndOfCheckPhase</string>
+            </dict>
+            <dict>
+                <key>Processor</key>
                 <string>CodeSignatureVerifier</string>
                 <key>Arguments</key>
                 <dict>

--- a/SURFdrive/surfdrive.download.recipe
+++ b/SURFdrive/surfdrive.download.recipe
@@ -40,6 +40,10 @@
 			<string>URLDownloader</string>
 		</dict>
 		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>purge_destination</key>
@@ -71,10 +75,6 @@
 					<string>Apple Root CA</string>
 				</array>
 			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
In order to use AutoPkg with the `--check` argument, download recipes must include an `EndOfCheckPhase` processor. This processor indicates where to stop processing when checking for new downloaded files. The proper placement of the processor is directly after the last `URLDownloader` or `URLDownloaderPython` processor to eliminate unnecessary processing (such as a code signature verification of an unchanged file).

This pull request adds the `EndOfCheckPhase` processor if is is missing and moves it to the correct location if it already exists.

Thanks for considering!

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0.